### PR TITLE
[T-136] 노래 리스트 + 바텀시트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,11 @@
 {
-  "extends": "next/core-web-vitals",
-  "plugins": ["perfectionist", "unused-imports", "prettier"],
+  "parser": "@typescript-eslint/parser",
+  "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/recommended"],
+  "plugins": ["perfectionist", "unused-imports", "prettier", "@typescript-eslint"],
   "rules": {
     "perfectionist/sort-enums": ["off"],
-    "no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
-    "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-vars": ["error"],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error"],
     "perfectionist/sort-imports": [
       "error",
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "@typescript-eslint/parser",
-  "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/recommended"],
+  "extends": ["next/core-web-vitals", "plugin:@typescript-eslint/recommended"],
   "plugins": ["perfectionist", "unused-imports", "prettier", "@typescript-eslint"],
   "rules": {
     "perfectionist/sort-enums": ["off"],

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'yt3.ggpht.com',
+      },
+    ],
+  },
+};
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "13.5.4",
     "react": "^18",
     "react-dom": "^18",
+    "react-youtube": "^10.1.0",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@typescript-eslint/eslint-plugin": "^6.18.0",
     "autoprefixer": "^10",
     "eslint": "^8.51.0",
     "eslint-config-next": "13.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/react-dom':
         specifier: ^18
         version: 18.2.11
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.18.0
+        version: 6.18.0(@typescript-eslint/parser@6.7.4)(eslint@8.51.0)(typescript@5.2.2)
       autoprefixer:
         specifier: ^10
         version: 10.4.16(postcss@8.4.31)
@@ -68,7 +71,7 @@ importers:
         version: 5.0.1(eslint-config-prettier@9.0.0)(eslint@8.51.0)(prettier@3.0.3)
       eslint-plugin-unused-imports:
         specifier: ^3.0.0
-        version: 3.0.0(eslint@8.51.0)
+        version: 3.0.0(@typescript-eslint/eslint-plugin@6.18.0)(eslint@8.51.0)
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -382,6 +385,35 @@ packages:
     resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
     dev: true
 
+  /@typescript-eslint/eslint-plugin@6.18.0(@typescript-eslint/parser@6.7.4)(eslint@8.51.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-3lqEvQUdCozi6d1mddWqd+kf8KxmGq2Plzx36BlkjuQe3rSTm/O98cLf0A4uDO+a5N1KD2SeEEl6fW97YHY+6w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.9.1
+      '@typescript-eslint/parser': 6.7.4(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/scope-manager': 6.18.0
+      '@typescript-eslint/type-utils': 6.18.0(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.18.0(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/visitor-keys': 6.18.0
+      debug: 4.3.4
+      eslint: 8.51.0
+      graphemer: 1.4.0
+      ignore: 5.2.4
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/parser@6.7.4(eslint@8.51.0)(typescript@5.2.2):
     resolution: {integrity: sha512-I5zVZFY+cw4IMZUeNCU7Sh2PO5O57F7Lr0uyhgCJmhN/BuTlnc55KxPonR4+EM3GBdfiCyGZye6DgMjtubQkmA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -403,6 +435,14 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/scope-manager@6.18.0:
+    resolution: {integrity: sha512-o/UoDT2NgOJ2VfHpfr+KBY2ErWvCySNUIX/X7O9g8Zzt/tXdpfEU43qbNk8LVuWUT2E0ptzTWXh79i74PP0twA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.18.0
+      '@typescript-eslint/visitor-keys': 6.18.0
+    dev: true
+
   /@typescript-eslint/scope-manager@6.7.4:
     resolution: {integrity: sha512-SdGqSLUPTXAXi7c3Ob7peAGVnmMoGzZ361VswK2Mqf8UOYcODiYvs8rs5ILqEdfvX1lE7wEZbLyELCW+Yrql1A==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -419,6 +459,31 @@ packages:
       '@typescript-eslint/visitor-keys': 6.8.0
     dev: true
 
+  /@typescript-eslint/type-utils@6.18.0(eslint@8.51.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-ZeMtrXnGmTcHciJN1+u2CigWEEXgy1ufoxtWcHORt5kGvpjjIlK9MUhzHm4RM8iVy6dqSaZA/6PVkX6+r+ChjQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.18.0(eslint@8.51.0)(typescript@5.2.2)
+      debug: 4.3.4
+      eslint: 8.51.0
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types@6.18.0:
+    resolution: {integrity: sha512-/RFVIccwkwSdW/1zeMx3hADShWbgBxBnV/qSrex6607isYjj05t36P6LyONgqdUrNLl5TYU8NIKdHUYpFvExkA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
   /@typescript-eslint/types@6.7.4:
     resolution: {integrity: sha512-o9XWK2FLW6eSS/0r/tgjAGsYasLAnOWg7hvZ/dGYSSNjCh+49k5ocPN8OmG5aZcSJ8pclSOyVKP2x03Sj+RrCA==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -427,6 +492,28 @@ packages:
   /@typescript-eslint/types@6.8.0:
     resolution: {integrity: sha512-p5qOxSum7W3k+llc7owEStXlGmSl8FcGvhYt8Vjy7FqEnmkCVlM3P57XQEGj58oqaBWDQXbJDZxwUWMS/EAPNQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree@6.18.0(typescript@5.2.2):
+    resolution: {integrity: sha512-klNvl+Ql4NsBNGB4W9TZ2Od03lm7aGvTbs0wYaFYsplVPhr+oeXjlPZCDI4U9jgJIDK38W1FKhacCFzCC+nbIg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.18.0
+      '@typescript-eslint/visitor-keys': 6.18.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@typescript-eslint/typescript-estree@6.7.4(typescript@5.2.2):
@@ -471,6 +558,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/utils@6.18.0(eslint@8.51.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-wiKKCbUeDPGaYEYQh1S580dGxJ/V9HI7K5sbGAVklyf+o5g3O+adnS4UNJajplF4e7z2q0uVBaTdT/yLb4XAVA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.51.0)
+      '@types/json-schema': 7.0.14
+      '@types/semver': 7.5.4
+      '@typescript-eslint/scope-manager': 6.18.0
+      '@typescript-eslint/types': 6.18.0
+      '@typescript-eslint/typescript-estree': 6.18.0(typescript@5.2.2)
+      eslint: 8.51.0
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/utils@6.8.0(eslint@8.51.0)(typescript@5.2.2):
     resolution: {integrity: sha512-dKs1itdE2qFG4jr0dlYLQVppqTE+Itt7GmIf/vX6CSvsW+3ov8PbWauVKyyfNngokhIO9sKZeRGCUo1+N7U98Q==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -488,6 +594,14 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.18.0:
+    resolution: {integrity: sha512-1wetAlSZpewRDb2h9p/Q8kRjdGuqdTAQbkJIOUMLug2LBLG+QOjiWoSj6/3B/hA9/tVTFFdtiKvAYoYnSRW/RA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.18.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@typescript-eslint/visitor-keys@6.7.4:
@@ -1354,7 +1468,7 @@ packages:
       string.prototype.matchall: 4.0.10
     dev: true
 
-  /eslint-plugin-unused-imports@3.0.0(eslint@8.51.0):
+  /eslint-plugin-unused-imports@3.0.0(@typescript-eslint/eslint-plugin@6.18.0)(eslint@8.51.0):
     resolution: {integrity: sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1364,6 +1478,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
+      '@typescript-eslint/eslint-plugin': 6.18.0(@typescript-eslint/parser@6.7.4)(eslint@8.51.0)(typescript@5.2.2)
       eslint: 8.51.0
       eslint-rule-composer: 0.3.0
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.2.0(react@18.2.0)
+      react-youtube:
+        specifier: ^10.1.0
+        version: 10.1.0(react@18.2.0)
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.0.0
@@ -883,6 +886,17 @@ packages:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
 
+  /debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.0.0
+    dev: false
+
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1502,7 +1516,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -2137,6 +2150,10 @@ packages:
       wrap-ansi: 8.1.0
     dev: true
 
+  /load-script@1.0.0:
+    resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
+    dev: false
+
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2220,6 +2237,10 @@ packages:
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
+
+  /ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2582,7 +2603,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
@@ -2604,7 +2624,20 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
+
+  /react-youtube@10.1.0(react@18.2.0):
+    resolution: {integrity: sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==}
+    engines: {node: '>= 14.x'}
+    peerDependencies:
+      react: '>=0.14.1'
+    dependencies:
+      fast-deep-equal: 3.1.3
+      prop-types: 15.8.1
+      react: 18.2.0
+      youtube-player: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -2783,6 +2816,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
     dev: true
+
+  /sister@3.0.2:
+    resolution: {integrity: sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==}
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3229,3 +3266,13 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /youtube-player@5.5.2:
+    resolution: {integrity: sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==}
+    dependencies:
+      debug: 2.6.9
+      load-script: 1.0.0
+      sister: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -1,28 +1,45 @@
+'use client';
+
+import { useRef } from 'react';
+import { YouTubeEvent } from 'react-youtube';
+
 import { Button } from '@/components/ui';
 
 import Cd from './Cd';
 import { Music } from './ListItem';
+import YoutubePlayer from './YoutubePlayer';
 
 export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
+  const eventRef = useRef<YouTubeEvent>(null);
+
+  const onClick = () => {
+    eventRef.current?.target.playVideo();
+  };
+
   return (
-    <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0">
-      <button className=" text-white  font-medium leading-[140%]">취소</button>
+    <>
+      <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 z-10 backdrop-blur-md">
+        <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
+          취소
+        </button>
 
-      <Cd src={selectMusic.thumbnailUrl} />
+        <Cd src={selectMusic.thumbnailUrl} />
 
-      <div className="flex flex-col items-center gap-4 w-full">
-        <div className="flex flex-col items-start gap-1 self-stretch">
-          <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
+        <div className="flex flex-col items-center gap-4 w-full">
+          <div className="flex flex-col items-start gap-1 self-stretch">
+            <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
 
-          <div className="flex items-start gap-1">
-            <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.artist}</div>
-            <div className="text-white-a20 text-center text-xs font-medium leading-[140%]">|</div>
-            <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.albumTitle}</div>
+            <div className="flex items-start gap-1">
+              <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.artist}</div>
+              <div className="text-white-a20 text-center text-xs font-medium leading-[140%]">|</div>
+              <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.albumTitle}</div>
+            </div>
           </div>
         </div>
-      </div>
 
-      <Button className="my-[1.25rem]">Share</Button>
-    </div>
+        <Button className="my-[1.25rem]">Share</Button>
+      </div>
+      <YoutubePlayer ref={eventRef} youtubeId={selectMusic.musicId} />
+    </>
   );
 }

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -9,7 +9,7 @@ import Cd from './Cd';
 import { Music } from './ListItem';
 import YoutubePlayer from './YoutubePlayer';
 
-export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
+export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Music; onClose: () => void }) {
   const eventRef = useRef<YouTubeEvent>(null);
 
   const onClick = () => {
@@ -18,6 +18,9 @@ export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
 
   return (
     <>
+      {/* 백그라운드 컴포넌트  */}
+      <div className="h-full w-full absolute top-0 z-0" onClick={onClose}></div>
+
       <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 z-10 backdrop-blur-md">
         <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
           취소

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui';
 
+import Cd from './Cd';
 import { Music } from './ListItem';
 
 export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
@@ -7,9 +8,7 @@ export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
     <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0">
       <button className=" text-white  font-medium leading-[140%]">취소</button>
 
-      <div className="flex justify-center mb-4">
-        <img className="flex-shrink-0 w-52 h-52 border rounded-full border-white-a20" src={selectMusic.thumbnailUrl} />
-      </div>
+      <Cd src={selectMusic.thumbnailUrl} />
 
       <div className="flex flex-col items-center gap-4 w-full">
         <div className="flex flex-col items-start gap-1 self-stretch">

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -1,0 +1,29 @@
+import { Button } from '@/components/ui';
+
+import { Music } from './ListItem';
+
+export default function BottomSheet({ selectMusic }: { selectMusic: Music }) {
+  return (
+    <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0">
+      <button className=" text-white  font-medium leading-[140%]">취소</button>
+
+      <div className="flex justify-center mb-4">
+        <img className="flex-shrink-0 w-52 h-52 border rounded-full border-white-a20" src={selectMusic.thumbnailUrl} />
+      </div>
+
+      <div className="flex flex-col items-center gap-4 w-full">
+        <div className="flex flex-col items-start gap-1 self-stretch">
+          <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
+
+          <div className="flex items-start gap-1">
+            <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.artist}</div>
+            <div className="text-white-a20 text-center text-xs font-medium leading-[140%]">|</div>
+            <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.albumTitle}</div>
+          </div>
+        </div>
+      </div>
+
+      <Button className="my-[1.25rem]">Share</Button>
+    </div>
+  );
+}

--- a/src/app/search/components/Cd.tsx
+++ b/src/app/search/components/Cd.tsx
@@ -1,0 +1,12 @@
+export default function Cd({ src }: { src: string }) {
+  return (
+    <div className="flex justify-center items-center mb-4">
+      <div className="absolute flex items-center justify-center">
+        <svg width={48} height={48} viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <circle cx={24} cy={24} r={24} fill="#101012" />
+        </svg>
+      </div>
+      <img className="flex-shrink-0 w-52 h-52 border rounded-full border-white-a20" src={src} />
+    </div>
+  );
+}

--- a/src/app/search/components/Cd.tsx
+++ b/src/app/search/components/Cd.tsx
@@ -1,12 +1,39 @@
+import Image from 'next/image';
+
 export default function Cd({ src }: { src: string }) {
   return (
-    <div className="flex justify-center items-center mb-4">
-      <div className="absolute flex items-center justify-center">
-        <svg width={48} height={48} viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx={24} cy={24} r={24} fill="#101012" />
-        </svg>
+    <>
+      <svg
+        className="absolute"
+        width="232"
+        height="232"
+        viewBox="0 0 232 232"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <mask id="mask">
+          <path
+            opacity="0.9"
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M116 232C180.065 232 232 180.065 232 116C232 51.935 180.065 0 116 0C51.935 0 0 51.935 0 116C0 180.065 51.935 232 116 232ZM117 145C132.464 145 145 132.464 145 117C145 101.536 132.464 89 117 89C101.536 89 89 101.536 89 117C89 132.464 101.536 145 117 145Z"
+            fill="#FFFFFF"
+          />
+        </mask>
+      </svg>
+
+      <div className="flex justify-center items-center mb-4">
+        <Image
+          alt=""
+          width={232}
+          height={232}
+          style={{
+            maskImage: 'url(#mask)',
+            WebkitMaskImage: 'url(#mask)',
+          }}
+          src={src}
+        />
       </div>
-      <img className="flex-shrink-0 w-52 h-52 border rounded-full border-white-a20" src={src} />
-    </div>
+    </>
   );
 }

--- a/src/app/search/components/List.tsx
+++ b/src/app/search/components/List.tsx
@@ -1,5 +1,14 @@
+import { FC } from 'react';
+
 import ListItem, { Music } from './ListItem';
 
-export default function List({ musicList }: { musicList: Music[] }) {
-  return musicList.map((music) => <ListItem key={music.id} music={music} />);
+interface Props {
+  musicList: Music[];
+  onListItemClick: (item: Music) => void;
 }
+
+const List: FC<Props> = ({ musicList, onListItemClick }) => {
+  return musicList.map((music) => <ListItem key={music.id} music={music} onClick={() => onListItemClick(music)} />);
+};
+
+export default List;

--- a/src/app/search/components/List.tsx
+++ b/src/app/search/components/List.tsx
@@ -1,0 +1,5 @@
+import ListItem, { Music } from './ListItem';
+
+export default function List({ musicList }: { musicList: Music[] }) {
+  return musicList.map((music) => <ListItem key={music.id} music={music} />);
+}

--- a/src/app/search/components/ListItem.tsx
+++ b/src/app/search/components/ListItem.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import Image from 'next/image';
+
 export interface Music {
   id: string;
   musicTitle: string;
@@ -5,23 +9,32 @@ export interface Music {
   albumTitle: string;
   thumbnailUrl: string;
   audioUrl: string;
+  musicId: string;
 }
 export default function ListItem({ music }: { music: Music }) {
   return (
-    <button className="flex items-center gap-4 py-2  w-full">
-      <img alt={''} src={music.thumbnailUrl} className="w-16 h-16 border border-[#ffffff]/[.20] rounded-full" />
-      <div className="flex flex-col items-start gap-0.5">
-        <div className="text-white-100  text-lg font-semibold leading-[140%]">{music.musicTitle}</div>
-        <div className="flex items-start gap-1">
-          <div className="text-white-a40  text-[.8125rem] font-medium leading-[140%] whitespace-nowrap">
-            {music.artist}
+    <>
+      <div className="flex items-center gap-4 py-2  w-full">
+        <Image
+          alt={''}
+          width={64}
+          height={64}
+          src={music.thumbnailUrl}
+          className="border border-[#ffffff]/[.20] rounded-full"
+        />
+        <button className="flex flex-col items-start gap-0.5">
+          <div className="text-white-100  text-lg font-semibold leading-[140%]">{music.musicTitle}</div>
+          <div className="flex items-start gap-1">
+            <div className="text-white-a40  text-[.8125rem] font-medium leading-[140%] whitespace-nowrap">
+              {music.artist}
+            </div>
+            <div className="text-white-a20 text-white text-center  text-xs font-medium leading-[140%]">|</div>
+            <div className="text-white-a40 text-[.8125rem] font-medium leading-[140%] line-clamp-1 break-all">
+              {music.albumTitle}
+            </div>
           </div>
-          <div className="text-white-a20 text-white text-center  text-xs font-medium leading-[140%]">|</div>
-          <div className="text-white-a40 text-[.8125rem] font-medium leading-[140%] line-clamp-1 break-all">
-            {music.albumTitle}
-          </div>
-        </div>
+        </button>
       </div>
-    </button>
+    </>
   );
 }

--- a/src/app/search/components/ListItem.tsx
+++ b/src/app/search/components/ListItem.tsx
@@ -11,10 +11,10 @@ export interface Music {
   audioUrl: string;
   musicId: string;
 }
-export default function ListItem({ music }: { music: Music }) {
+export default function ListItem({ music, onClick }: { music: Music; onClick: () => void }) {
   return (
     <>
-      <div className="flex items-center gap-4 py-2  w-full">
+      <button className="flex items-center gap-4 py-2  w-full" onClick={onClick}>
         <Image
           alt={''}
           width={64}
@@ -22,7 +22,7 @@ export default function ListItem({ music }: { music: Music }) {
           src={music.thumbnailUrl}
           className="border border-[#ffffff]/[.20] rounded-full"
         />
-        <button className="flex flex-col items-start gap-0.5">
+        <div className="flex flex-col items-start gap-0.5">
           <div className="text-white-100  text-lg font-semibold leading-[140%]">{music.musicTitle}</div>
           <div className="flex items-start gap-1">
             <div className="text-white-a40  text-[.8125rem] font-medium leading-[140%] whitespace-nowrap">
@@ -33,8 +33,8 @@ export default function ListItem({ music }: { music: Music }) {
               {music.albumTitle}
             </div>
           </div>
-        </button>
-      </div>
+        </div>
+      </button>
     </>
   );
 }

--- a/src/app/search/components/ListItem.tsx
+++ b/src/app/search/components/ListItem.tsx
@@ -1,0 +1,27 @@
+export interface Music {
+  id: string;
+  musicTitle: string;
+  artist: string;
+  albumTitle: string;
+  thumbnailUrl: string;
+  audioUrl: string;
+}
+export default function ListItem({ music }: { music: Music }) {
+  return (
+    <button className="flex items-center gap-4 py-2  w-full">
+      <img alt={''} src={music.thumbnailUrl} className="w-16 h-16 border border-[#ffffff]/[.20] rounded-full" />
+      <div className="flex flex-col items-start gap-0.5">
+        <div className="text-white-100  text-lg font-semibold leading-[140%]">{music.musicTitle}</div>
+        <div className="flex items-start gap-1">
+          <div className="text-white-a40  text-[.8125rem] font-medium leading-[140%] whitespace-nowrap">
+            {music.artist}
+          </div>
+          <div className="text-white-a20 text-white text-center  text-xs font-medium leading-[140%]">|</div>
+          <div className="text-white-a40 text-[.8125rem] font-medium leading-[140%] line-clamp-1 break-all">
+            {music.albumTitle}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/app/search/components/YoutubePlayer.tsx
+++ b/src/app/search/components/YoutubePlayer.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { forwardRef, useEffect, useRef } from 'react';
+import YouTube, { YouTubeEvent, YouTubeProps } from 'react-youtube';
+
+const YoutubePlayer = forwardRef<YouTubeEvent, { youtubeId: string }>(({ youtubeId }, ref) => {
+  const opts = useRef<YouTubeProps['opts']>(null);
+
+  useEffect(() => {
+    opts.current = {
+      height: '200px',
+      width: '200px',
+      playerVars: {
+        // https://developers.google.com/youtube/player_parameters
+        autoplay: 0,
+      },
+    };
+  }, []);
+
+  const onPlayerReady: YouTubeProps['onReady'] = (event) => {
+    if (!ref || typeof ref === 'function') return;
+
+    ref.current = event;
+  };
+
+  return (
+    <YouTube
+      videoId={youtubeId}
+      opts={opts}
+      className="absolute bottom-0 left-0 z-[-10] w-[200px] h-[200px] overflow-hidden"
+      onReady={onPlayerReady}
+    />
+  );
+});
+
+YoutubePlayer.displayName = 'YoutubePlayer';
+
+export default YoutubePlayer;

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 
 import { Input } from '@/components/ui';
 
@@ -54,6 +54,11 @@ const musicList_MOCK: Music[] = [
 
 export default function Search() {
   const [selectMusic, setSelectMusic] = useState<Music | null>(null);
+  const [query, setQuery] = useState<string>('');
+
+  useEffect(() => {
+    console.log('query', query);
+  }, []);
 
   const onListItemClick = (music: Music) => {
     setSelectMusic(music);
@@ -63,10 +68,14 @@ export default function Search() {
     setSelectMusic(null);
   };
 
+  const onQueryChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
   return (
     <>
       <div className="px-4 border-border">
-        <Input placeholder="노래, 아티스트, 앨범명 등을 검색하세요." />
+        <Input placeholder="노래, 아티스트, 앨범명 등을 검색하세요." value={query} onChange={onQueryChange} />
 
         <div className="w-full py-[15px]">
           <p className="text-[12px]/[140%] text-white-a40">최근 찾은 노래</p>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useState } from 'react';
+
 import { Input } from '@/components/ui';
 
 import BottomSheet from './components/BottomSheet';
@@ -14,19 +18,51 @@ const musicList_MOCK: Music[] = [
     thumbnailUrl:
       'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
     audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+    musicId: 'hIoKUSDbapY',
   },
   {
     id: '2',
-    musicTitle: 'Beat Box',
+    musicTitle: '크리스마수',
     artist: 'NCT Dream',
     albumTitle: 'Beatbox - The 2nd Album Repackage',
     thumbnailUrl:
       'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
     audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+    musicId: '98kjNRfADKw',
+  },
+  {
+    id: '3',
+    musicTitle: '르세라핌1',
+    artist: 'NCT Dream',
+    albumTitle: 'Beatbox - The 2nd Album Repackage',
+    thumbnailUrl:
+      'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
+    audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+    musicId: 'SPNJgjqqUnI',
+  },
+  {
+    id: '4',
+    musicTitle: '르세라핌2',
+    artist: 'NCT Dream',
+    albumTitle: 'Beatbox - The 2nd Album Repackage',
+    thumbnailUrl:
+      'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
+    audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+    musicId: 'wERAXKNizk4',
   },
 ];
 
 export default function Search() {
+  const [selectMusic, setSelectMusic] = useState<Music | null>(null);
+
+  const onListItemClick = (music: Music) => {
+    setSelectMusic(music);
+  };
+
+  const onBottomSheetClose = () => {
+    setSelectMusic(null);
+  };
+
   return (
     <>
       <div className="px-4 border-border">
@@ -36,9 +72,9 @@ export default function Search() {
           <p className="text-[12px]/[140%] text-white-a40">최근 찾은 노래</p>
         </div>
 
-        <List musicList={musicList_MOCK} />
+        <List musicList={musicList_MOCK} onListItemClick={onListItemClick} />
       </div>
-      <BottomSheet selectMusic={musicList_MOCK[0]} />
+      {selectMusic && <BottomSheet selectMusic={selectMusic} onClose={onBottomSheetClose} />}
     </>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,9 +1,11 @@
 import { Input } from '@/components/ui';
 
+import BottomSheet from './components/BottomSheet';
 import List from './components/List';
+import { Music } from './components/ListItem';
 
 // @todo: api로 받아오기
-const musicList_MOCK = [
+const musicList_MOCK: Music[] = [
   {
     id: '1',
     musicTitle: 'musicTitle',
@@ -26,14 +28,17 @@ const musicList_MOCK = [
 
 export default function Search() {
   return (
-    <div className="px-4 border-border">
-      <Input placeholder="노래, 아티스트, 앨범명 등을 검색하세요." />
+    <>
+      <div className="px-4 border-border">
+        <Input placeholder="노래, 아티스트, 앨범명 등을 검색하세요." />
 
-      <div className="w-full py-[15px]">
-        <p className="text-[12px]/[140%] text-white-a40">최근 찾은 노래</p>
+        <div className="w-full py-[15px]">
+          <p className="text-[12px]/[140%] text-white-a40">최근 찾은 노래</p>
+        </div>
+
+        <List musicList={musicList_MOCK} />
       </div>
-
-      <List musicList={musicList_MOCK} />
-    </div>
+      <BottomSheet selectMusic={musicList_MOCK[0]} />
+    </>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,3 +1,39 @@
+import { Input } from '@/components/ui';
+
+import List from './components/List';
+
+// @todo: api로 받아오기
+const musicList_MOCK = [
+  {
+    id: '1',
+    musicTitle: 'musicTitle',
+    artist: 'aespa',
+    albumTitle: 'MY WORLD - The 3rd Mini Album',
+    thumbnailUrl:
+      'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
+    audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+  },
+  {
+    id: '2',
+    musicTitle: 'Beat Box',
+    artist: 'NCT Dream',
+    albumTitle: 'Beatbox - The 2nd Album Repackage',
+    thumbnailUrl:
+      'https://yt3.ggpht.com/aMEvgk3HpePuKHEb72ZLb0RHnq4oZc9JoLZP2SiIoC8VJmGGSvChE7GtNRY3twnlhQ1nMMsX_g=s88-c-k-c0x00ffffff-no-rj',
+    audioUrl: 'https://www.youtube.com/watch?v=WM7S317ebLM',
+  },
+];
+
 export default function Search() {
-  return <div>검색</div>;
+  return (
+    <div className="px-4 border-border">
+      <Input placeholder="노래, 아티스트, 앨범명 등을 검색하세요." />
+
+      <div className="w-full py-[15px]">
+        <p className="text-[12px]/[140%] text-white-a40">최근 찾은 노래</p>
+      </div>
+
+      <List musicList={musicList_MOCK} />
+    </div>
+  );
 }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type,
     <input
       type={type}
       className={cn(
-        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        `flex w-full border-b-2 bg-background pb-2 pt-4 text-white-100 placeholder:text-white-a60 disabled:cursor-not-allowed`,
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Key Changes
- 노래의 리스트를 받아 리스트뷰 + 바텀시트를 그리는 컴포넌트 작업
- 유튜브 라이브러리를 연동해 바텀시트 오픈 시 노래 재생 기능 구현 
  - (추가작업) 유튜브 컴포넌트가 가장 마지막에 뜨도록 추가 작업 필요
  - (추가작업) 바텀시트 애니메이션 필요
  - (추가작업) 바텀시트 피쳐는 따로 PR 작성 예정

## Screenshots

<!-- UXUI가 변경된 PR인경우, 테스트 스크린샷을 반드시 첨부해요. (아닌경우 제거) -->

https://github.com/getmymy/mymy-client/assets/76904042/9a090a60-03e4-47ff-a77c-8ec00ba393b5


## To Reviewers