### PR TITLE
바텀시트 애니메이션 + 음악 재생 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
+    "framer-motion": "^10.17.9",
     "lucide-react": "^0.292.0",
     "next": "13.5.4",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.0.0
+      framer-motion:
+        specifier: ^10.17.9
+        version: 10.17.9(react-dom@18.2.0)(react@18.2.0)
       lucide-react:
         specifier: ^0.292.0
         version: 0.292.0(react@18.2.0)
@@ -107,6 +110,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
+
+  /@emotion/is-prop-valid@0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    requiresBuild: true
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: false
+    optional: true
+
+  /@emotion/memoize@0.7.4:
+    resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.51.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -1702,6 +1719,24 @@ packages:
   /fraction.js@4.3.6:
     resolution: {integrity: sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==}
     dev: true
+
+  /framer-motion@10.17.9(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-z2NpP8r+XuALoPA7ZVZHm/OoTnwkQNJFBu91sC86o/FYvJ4x7ar3eQnixgwYWFK7kEqOtQ6whtNM37tn1KrOOA==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.6.2
+    optionalDependencies:
+      '@emotion/is-prop-valid': 0.8.8
+    dev: false
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { YouTubeEvent } from 'react-youtube';
 
 import { AnimatePresence, motion } from 'framer-motion';
@@ -18,19 +19,19 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
     eventRef.current?.target.playVideo();
   };
 
-  return (
+  return createPortal(
     <AnimatePresence>
       {selectMusic && (
-        <>
+        <div className="absolute h-full w-full top-0 overflow-hidden">
           {/* 백그라운드 컴포넌트  */}
-          <div className="h-full w-full absolute top-0 z-0" onClick={onClose}></div>
+          <div className="h-full w-full absolute top-0" onClick={onClose}></div>
 
           <motion.div
             key="modal"
             initial={{ opacity: 0, y: 100 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 50 }}
-            className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 z-10 backdrop-blur-md"
+            className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 backdrop-blur-md"
           >
             <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
               취소
@@ -38,6 +39,7 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
 
             <Cd src={selectMusic.thumbnailUrl} />
 
+            {/* @todo: 타이포 컴포넌트로 변경 */}
             <div className="flex flex-col items-center gap-4 w-full">
               <div className="flex flex-col items-start gap-1 self-stretch">
                 <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
@@ -53,8 +55,9 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
             <Button className="my-[1.25rem]">Share</Button>
           </motion.div>
           <YoutubePlayer ref={eventRef} youtubeId={selectMusic.musicId} />
-        </>
+        </div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -3,13 +3,15 @@
 import { useRef } from 'react';
 import { YouTubeEvent } from 'react-youtube';
 
+import { AnimatePresence, motion } from 'framer-motion';
+
 import { Button } from '@/components/ui';
 
 import Cd from './Cd';
 import { Music } from './ListItem';
 import YoutubePlayer from './YoutubePlayer';
 
-export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Music; onClose: () => void }) {
+export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Music | null; onClose: () => void }) {
   const eventRef = useRef<YouTubeEvent>(null);
 
   const onClick = () => {
@@ -17,32 +19,42 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
   };
 
   return (
-    <>
-      {/* 백그라운드 컴포넌트  */}
-      <div className="h-full w-full absolute top-0 z-0" onClick={onClose}></div>
+    <AnimatePresence>
+      {selectMusic && (
+        <>
+          {/* 백그라운드 컴포넌트  */}
+          <div className="h-full w-full absolute top-0 z-0" onClick={onClose}></div>
 
-      <div className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 z-10 backdrop-blur-md">
-        <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
-          취소
-        </button>
+          <motion.div
+            key="modal"
+            initial={{ opacity: 0, y: 100 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 50 }}
+            className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 z-10 backdrop-blur-md"
+          >
+            <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
+              취소
+            </button>
 
-        <Cd src={selectMusic.thumbnailUrl} />
+            <Cd src={selectMusic.thumbnailUrl} />
 
-        <div className="flex flex-col items-center gap-4 w-full">
-          <div className="flex flex-col items-start gap-1 self-stretch">
-            <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
+            <div className="flex flex-col items-center gap-4 w-full">
+              <div className="flex flex-col items-start gap-1 self-stretch">
+                <div className="text-white text-2xl font-bold leading-[140%]">{selectMusic.musicTitle}</div>
 
-            <div className="flex items-start gap-1">
-              <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.artist}</div>
-              <div className="text-white-a20 text-center text-xs font-medium leading-[140%]">|</div>
-              <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.albumTitle}</div>
+                <div className="flex items-start gap-1">
+                  <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.artist}</div>
+                  <div className="text-white-a20 text-center text-xs font-medium leading-[140%]">|</div>
+                  <div className="text-white-a60 font-medium leading-[140%]">{selectMusic.albumTitle}</div>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
 
-        <Button className="my-[1.25rem]">Share</Button>
-      </div>
-      <YoutubePlayer ref={eventRef} youtubeId={selectMusic.musicId} />
-    </>
+            <Button className="my-[1.25rem]">Share</Button>
+          </motion.div>
+          <YoutubePlayer ref={eventRef} youtubeId={selectMusic.musicId} />
+        </>
+      )}
+    </AnimatePresence>
   );
 }

--- a/src/app/search/components/BottomSheet.tsx
+++ b/src/app/search/components/BottomSheet.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { YouTubeEvent } from 'react-youtube';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import VolumeOff from '@/components/icon/VolumeOff';
+import VolumeOn from '@/components/icon/VolumeOn';
 import { Button } from '@/components/ui';
 
 import Cd from './Cd';
@@ -14,9 +16,30 @@ import YoutubePlayer from './YoutubePlayer';
 
 export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Music | null; onClose: () => void }) {
   const eventRef = useRef<YouTubeEvent>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
 
-  const onClick = () => {
+  useEffect(() => {
+    if (!selectMusic) {
+      setIsPlaying(false);
+    }
+  }, [selectMusic]);
+
+  const playMusic = () => {
     eventRef.current?.target.playVideo();
+  };
+
+  const pauseMusic = () => {
+    eventRef.current?.target.pauseVideo();
+  };
+
+  const onMusicClick = () => {
+    if (isPlaying) {
+      pauseMusic();
+      setIsPlaying(false);
+    } else {
+      playMusic();
+      setIsPlaying(true);
+    }
   };
 
   return createPortal(
@@ -33,9 +56,17 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
             exit={{ opacity: 0, y: 50 }}
             className="flex-shrink-0 pt-5 px-5 w-full rounded-t-[30px] bg-white-a10 absolute bottom-0 backdrop-blur-md"
           >
-            <button onClick={onClick} className=" text-white  font-medium leading-[140%]">
-              취소
-            </button>
+            <div className="flex justify-between">
+              <button onClick={onClose} className=" text-white  font-medium leading-[140%]">
+                취소
+              </button>
+              <button
+                onClick={onMusicClick}
+                className="flex items-center justify-center w-[32px] h-[32px] bg-white-a20 rounded-full"
+              >
+                {isPlaying ? <VolumeOff /> : <VolumeOn />}
+              </button>
+            </div>
 
             <Cd src={selectMusic.thumbnailUrl} />
 
@@ -52,6 +83,7 @@ export default function BottomSheet({ selectMusic, onClose }: { selectMusic: Mus
               </div>
             </div>
 
+            {/* @todo: button 컴포넌트 업데이트 반영 */}
             <Button className="my-[1.25rem]">Share</Button>
           </motion.div>
           <YoutubePlayer ref={eventRef} youtubeId={selectMusic.musicId} />

--- a/src/app/search/components/Cd.tsx
+++ b/src/app/search/components/Cd.tsx
@@ -14,8 +14,8 @@ export default function Cd({ src }: { src: string }) {
         <mask id="mask">
           <path
             opacity="0.9"
-            fill-rule="evenodd"
-            clip-rule="evenodd"
+            fillRule="evenodd"
+            clipRule="evenodd"
             d="M116 232C180.065 232 232 180.065 232 116C232 51.935 180.065 0 116 0C51.935 0 0 51.935 0 116C0 180.065 51.935 232 116 232ZM117 145C132.464 145 145 132.464 145 117C145 101.536 132.464 89 117 89C101.536 89 89 101.536 89 117C89 132.464 101.536 145 117 145Z"
             fill="#FFFFFF"
           />

--- a/src/app/search/components/YoutubePlayer.tsx
+++ b/src/app/search/components/YoutubePlayer.tsx
@@ -24,12 +24,15 @@ const YoutubePlayer = forwardRef<YouTubeEvent, { youtubeId: string }>(({ youtube
   };
 
   return (
-    <YouTube
-      videoId={youtubeId}
-      opts={opts}
-      className="absolute bottom-0 left-0 z-[-10] w-[200px] h-[200px] overflow-hidden"
-      onReady={onPlayerReady}
-    />
+    <>
+      <div className="absolute bottom-0 left-0 -z-10 w-[200px] h-[200px] overflow-hidden bg-background"></div>
+      <YouTube
+        videoId={youtubeId}
+        opts={opts}
+        className="absolute bottom-0 left-0 -z-20 w-[200px] h-[200px] overflow-hidden"
+        onReady={onPlayerReady}
+      />
+    </>
   );
 });
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -83,7 +83,7 @@ export default function Search() {
 
         <List musicList={musicList_MOCK} onListItemClick={onListItemClick} />
       </div>
-      {selectMusic && <BottomSheet selectMusic={selectMusic} onClose={onBottomSheetClose} />}
+      <BottomSheet selectMusic={selectMusic} onClose={onBottomSheetClose} />
     </>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 
 import { Input } from '@/components/ui';
 
@@ -55,10 +55,6 @@ const musicList_MOCK: Music[] = [
 export default function Search() {
   const [selectMusic, setSelectMusic] = useState<Music | null>(null);
   const [query, setQuery] = useState<string>('');
-
-  useEffect(() => {
-    console.log('query', query);
-  }, []);
 
   const onListItemClick = (music: Music) => {
     setSelectMusic(music);

--- a/src/components/icon/VolumeOff.tsx
+++ b/src/components/icon/VolumeOff.tsx
@@ -1,0 +1,29 @@
+const VolumeOff = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+      <path
+        d="M8.25 3.75L4.5 6.75H1.5V11.25H4.5L8.25 14.25V3.75Z"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.655 6.345C12.358 7.04823 12.753 8.00189 12.753 8.99625C12.753 9.99062 12.358 10.9443 11.655 11.6475"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.2106 4.73685C15.4238 5.86763 16.1053 7.40108 16.1053 9C16.1053 10.5989 15.4238 12.1324 14.2106 13.2632"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default VolumeOff;

--- a/src/components/icon/VolumeOn.tsx
+++ b/src/components/icon/VolumeOn.tsx
@@ -1,0 +1,29 @@
+const VolumeOn = () => {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+      <path
+        d="M8.25 3.75L4.5 6.75H1.5V11.25H4.5L8.25 14.25V3.75Z"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16.3026 6.75L11.8026 11.25"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M11.8026 6.75L16.3026 11.25"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default VolumeOn;


### PR DESCRIPTION
## Key Changes
- framer-motion을 사용해서 바텀시트 애니메이션을 구현했어요.
  - fade-out 애니메이션을 위해 <AnimatePresence/> 태그로 감싸주었어요.

## Screenshots

<!-- UXUI가 변경된 PR인경우, 테스트 스크린샷을 반드시 첨부해요. (아닌경우 제거) -->

https://github.com/getmymy/mymy-client/assets/76904042/6a654248-795e-421e-8488-20332372416d


## To Reviewers

<!-- - 리뷰어에게 집중적으로 리뷰를 부탁하고 싶은 부분등을 요청하거나 그 밖에 리뷰어에게 요청하고 싶은 내용을 말해요. -->
